### PR TITLE
Fix extension activation and build errors

### DIFF
--- a/src/services/MCPServer.ts
+++ b/src/services/MCPServer.ts
@@ -12,10 +12,11 @@ export function startMCPServer(context: vscode.ExtensionContext) {
     // Path to the compiled server runner script
     const serverRunnerPath = path.join(context.extensionPath, 'out', 'src', 'mcp-server-runner.js');
 
-    // Use 'node' to execute the script.
-    const serverProcess = spawn('node', [serverRunnerPath], {
+    // Use the same Node.js executable that is running the extension host.
+    const serverProcess = spawn(process.execPath, [serverRunnerPath], {
         stdio: ['pipe', 'pipe', 'pipe'], // stdin, stdout, stderr
-        shell: false
+        shell: false,
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
     });
 
     // Log stdout from the server process for debugging


### PR DESCRIPTION
This commit resolves critical build and runtime errors that prevented the VS Code extension from activating and running correctly.

The debugging process identified two categories of issues:

1.  **Build and Configuration Errors:**
    *   Incorrect module imports in TypeScript files (using `.js` extensions) were corrected to align with the CommonJS module system used by VS Code extensions.
    *   A `Permission denied` error for the `vite` build tool was resolved by adding a `postinstall` script to `webview/package.json` to make the binary executable.
    *   A comprehensive `.gitignore` was added to prevent build artifacts and test downloads from being tracked by Git, resolving issues with file count limits in the environment.

2.  **Runtime Activation Failure:**
    *   The root cause of the extension failing to activate silently was the unreliable method of spawning the MCP server child process. The command `spawn('node', ...)` is not guaranteed to work within the VS Code extension host environment.
    *   This was fixed by using `process.execPath` to get the correct path to the Node.js executable running the extension. The `ELECTRON_RUN_AS_NODE: '1'` environment variable was also added, which is essential for correctly spawning Node.js child processes from within an Electron application.